### PR TITLE
Fix - E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
     needs: deploy-app
     runs-on: ubuntu-latest
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:


### PR DESCRIPTION
```sh
internal/fs/utils.js:220
    throw err;
    ^

Error: ENOENT: no such file or directory, open '/home/runner/work/divergent-console/divergent-console/app/package-lock.json'
    at Object.openSync (fs.js:440:3)
    at Object.readFileSync (fs.js:342:35)
    at Function.module.exports.hasha.fromFileSync (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:22856:54)
    at lockHash (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:8604:26)
    at getNpmCache (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:8614:16)
    at restoreCachedNpm (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:8663:21)
    at installMaybe (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:9208:5)
    at Object.<anonymous> (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:9231:1)
    at __webpack_require__ (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:24:31)
    at startup (/home/runner/work/_actions/cypress-io/github-action/v2/dist/index.js:43:19) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/home/runner/work/divergent-console/divergent-console/app/package-lock.json'
}
```